### PR TITLE
Update tools spec declaration on documentation

### DIFF
--- a/docs/src/content/docs/agents/built-in/bedrock-llm-agent.mdx
+++ b/docs/src/content/docs/agents/built-in/bedrock-llm-agent.mdx
@@ -134,7 +134,7 @@ For more complex use cases, you can create a **Bedrock LLM Agent** with all avai
         },
         retriever=Retriever(),  # Assuming you have a Retriever class implemented
         tool_config={
-            'tool': {"tools": [
+            'tool': {'tools': [
                 {
                     'toolSpec': {
                         'name': 'get_current_weather',

--- a/docs/src/content/docs/agents/built-in/bedrock-llm-agent.mdx
+++ b/docs/src/content/docs/agents/built-in/bedrock-llm-agent.mdx
@@ -134,7 +134,7 @@ For more complex use cases, you can create a **Bedrock LLM Agent** with all avai
         },
         retriever=Retriever(),  # Assuming you have a Retriever class implemented
         tool_config={
-            'tool': [
+            'tool': {"tools": [
                 {
                     'toolSpec': {
                         'name': 'get_current_weather',
@@ -154,7 +154,8 @@ For more complex use cases, you can create a **Bedrock LLM Agent** with all avai
                         }
                     }
                 }
-            ],
+              ]
+            },
             'useToolHandler': lambda response, conversation: (False, response)  # Process tool response
         }
     )


### PR DESCRIPTION
I found out an error on toolSpec, we must have a class dict type with "tools" key and after that an class list with each toolSpec

This cause a validation error from Bedrock API : 

Invalid type for parameter toolConfig, value: [{'toolSpec': {'name': 'xxxx', 'description': "xxxx", 'inputSchema': {'json': {'type': 'object', 'properties': {'field1': {'type': 'string', 'description': 'xxxx'}}, 'required': ['field1']}}}}], type: <class 'list'>, valid types: <class 'dict'>

<!-- markdownlint-disable MD041 MD043 -->
**Issue number: https://github.com/awslabs/multi-agent-orchestrator/issues/34

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
